### PR TITLE
Fix Extra Gears for game patch 1.2

### DIFF
--- a/extraGears.lua
+++ b/extraGears.lua
@@ -131,7 +131,24 @@ function Motorized:onRegisterActionEvents(isActiveForInput, isActiveForInputIgno
                         _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.SHIFT_GEAR_SELECT_8, self, Motorized.actionEventSelectGear, true, true, true, true, 8)
                         g_inputBinding:setActionEventTextVisibility(actionEventId, false)
 
-                        print("ExtraGears -- Override Motorized:onRegisterActionEvents for vehicle motor registration 9->18")
+                        print("ExtraGears -- Override Motorized:onRegisterActionEvents for vehicle motor registration 1->18")
+                        _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_1, self, Motorized.actionEventSelectGear, true, true, true, true, 1)
+                        g_inputBinding:setActionEventTextVisibility(actionEventId, false)
+                        _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_2, self, Motorized.actionEventSelectGear, true, true, true, true, 2)
+                        g_inputBinding:setActionEventTextVisibility(actionEventId, false)
+                        _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_3, self, Motorized.actionEventSelectGear, true, true, true, true, 3)
+                        g_inputBinding:setActionEventTextVisibility(actionEventId, false)
+                        _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_4, self, Motorized.actionEventSelectGear, true, true, true, true, 4)
+                        g_inputBinding:setActionEventTextVisibility(actionEventId, false)
+                        _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_5, self, Motorized.actionEventSelectGear, true, true, true, true, 5)
+                        g_inputBinding:setActionEventTextVisibility(actionEventId, false)
+                        _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_6, self, Motorized.actionEventSelectGear, true, true, true, true, 6)
+                        g_inputBinding:setActionEventTextVisibility(actionEventId, false)
+                        _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_7, self, Motorized.actionEventSelectGear, true, true, true, true, 7)
+                        g_inputBinding:setActionEventTextVisibility(actionEventId, false)
+                        _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_8, self, Motorized.actionEventSelectGear, true, true, true, true, 8)
+                        g_inputBinding:setActionEventTextVisibility(actionEventId, false)
+
                         -- add 9 -> 18
                         _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.EXG_GEAR_9, self, Motorized.actionEventSelectGear, true, true, true, true, 9)
                         g_inputBinding:setActionEventTextVisibility(actionEventId, false)
@@ -272,15 +289,25 @@ function MotorGearShiftEvent.sendEvent(vehicle, shiftType, shiftValue)
     if g_client ~= nil then
         if shiftType == MotorGearShiftEvent.TYPE_SELECT_GEAR then
             --sanity check
+
+            local inp = shiftValue;
+
             if nill == ExtraGears.shiftGearOverrideAmount then
                 ExtraGears.shiftGearOverrideAmount = 0
             end
             -- print("ExtraGears - in shiftevent sendEvent - " ..tostring(shiftValue) .." | " ..tostring(ExtraGears.shiftGearOverrideAmount));
             -- is the stick in neutral?
             -- only bump if not in neutral
+
+            -- 1.2 patch
+            -- if shiftValue > 1 then
+            --     shiftValue = shiftValue - (keybind - 1);
+            -- end
+
             if shiftValue > 0 then
                 shiftValue = shiftValue + ExtraGears.shiftGearOverrideAmount;
             end
+            print("ExtraGears - in shiftevent resolved " ..tostring(inp) ..tostring(' ') ..tostring(ExtraGears.shiftGearOverrideAmount) ..(' ') ..tostring(shiftValue));
             -- print("ExtraGears - in shiftevent resolved " ..tostring(shiftValue));
         end
 

--- a/l10n/l10n_cz.xml
+++ b/l10n/l10n_cz.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <texts>
+        <text name="input_EXG_GEAR_1" text="Stupeň 1"/>
+        <text name="input_EXG_GEAR_2" text="Stupeň 2"/>
+        <text name="input_EXG_GEAR_3" text="Stupeň 3"/>
+        <text name="input_EXG_GEAR_4" text="Stupeň 4"/>
+        <text name="input_EXG_GEAR_5" text="Stupeň 5"/>
+        <text name="input_EXG_GEAR_6" text="Stupeň 6"/>
+        <text name="input_EXG_GEAR_7" text="Stupeň 7"/>
+        <text name="input_EXG_GEAR_8" text="Stupeň 8"/>
         <text name="input_EXG_GEAR_9" text="Stupeň 9"/>
         <text name="input_EXG_GEAR_10" text="Stupeň 10"/>
         <text name="input_EXG_GEAR_11" text="Stupeň 11"/>

--- a/l10n/l10n_de.xml
+++ b/l10n/l10n_de.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <texts>
+        <text name="input_EXG_GEAR_1" text="1. Gang"/>
+        <text name="input_EXG_GEAR_2" text="2. Gang"/>
+        <text name="input_EXG_GEAR_3" text="3. Gang"/>
+        <text name="input_EXG_GEAR_4" text="4. Gang"/>
+        <text name="input_EXG_GEAR_5" text="5. Gang"/>
+        <text name="input_EXG_GEAR_6" text="6. Gang"/>
+        <text name="input_EXG_GEAR_7" text="7. Gang"/>
+        <text name="input_EXG_GEAR_8" text="8. Gang"/>
         <text name="input_EXG_GEAR_9" text="9. Gang"/>
         <text name="input_EXG_GEAR_10" text="10. Gang"/>
         <text name="input_EXG_GEAR_11" text="11. Gang"/>

--- a/l10n/l10n_en.xml
+++ b/l10n/l10n_en.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <texts>
+        <text name="input_EXG_GEAR_1" text="Gear 1"/>
+        <text name="input_EXG_GEAR_2" text="Gear 2"/>
+        <text name="input_EXG_GEAR_3" text="Gear 3"/>
+        <text name="input_EXG_GEAR_4" text="Gear 4"/>
+        <text name="input_EXG_GEAR_5" text="Gear 5"/>
+        <text name="input_EXG_GEAR_6" text="Gear 6"/>
+        <text name="input_EXG_GEAR_7" text="Gear 7"/>
+        <text name="input_EXG_GEAR_8" text="Gear 8"/>
         <text name="input_EXG_GEAR_9" text="Gear 9"/>
         <text name="input_EXG_GEAR_10" text="Gear 10"/>
         <text name="input_EXG_GEAR_11" text="Gear 11"/>

--- a/l10n/l10n_it.xml
+++ b/l10n/l10n_it.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <texts>
+        <text name="input_EXG_GEAR_1" text="Marcia 1"/>
+        <text name="input_EXG_GEAR_2" text="Marcia 2"/>
+        <text name="input_EXG_GEAR_3" text="Marcia 3"/>
+        <text name="input_EXG_GEAR_4" text="Marcia 4"/>
+        <text name="input_EXG_GEAR_5" text="Marcia 5"/>
+        <text name="input_EXG_GEAR_6" text="Marcia 6"/>
+        <text name="input_EXG_GEAR_7" text="Marcia 7"/>
+        <text name="input_EXG_GEAR_8" text="Marcia 8"/>
+
         <text name="input_EXG_GEAR_9" text="Marcia 9"/>
         <text name="input_EXG_GEAR_10" text="Marcia 10"/>
         <text name="input_EXG_GEAR_11" text="Marcia 11"/>

--- a/l10n/l10n_nl.xml
+++ b/l10n/l10n_nl.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <texts>
+        <text name="input_EXG_GEAR_1" text="Versnelling 1"/>
+        <text name="input_EXG_GEAR_2" text="Versnelling 2"/>
+        <text name="input_EXG_GEAR_3" text="Versnelling 3"/>
+        <text name="input_EXG_GEAR_4" text="Versnelling 4"/>
+        <text name="input_EXG_GEAR_5" text="Versnelling 5"/>
+        <text name="input_EXG_GEAR_6" text="Versnelling 6"/>
+        <text name="input_EXG_GEAR_7" text="Versnelling 7"/>
+        <text name="input_EXG_GEAR_8" text="Versnelling 8"/>
+
         <text name="input_EXG_GEAR_9" text="Versnelling 9"/>
         <text name="input_EXG_GEAR_10" text="Versnelling 10"/>
         <text name="input_EXG_GEAR_11" text="Versnelling 11"/>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -5,7 +5,7 @@
     <title>
         <en>Extra Gears</en>
         <de>Weitere Gänge</de>
-	<cz>Extra rychlostní stupně</cz>
+        <cz>Extra rychlostní stupně</cz>
         <it>Marce Extra</it>
         <nl>Extra versnellingen</nl>
     </title>
@@ -20,6 +20,7 @@ Extra Gears adds keybindings up to 18. For direct Shifter access and adds Gear G
 Additionally for those with a six or eight speed shifter, you can bind "shift" keys to use the same six or eight to access higher gears. This is similar to other Simulator Games.
 
 You can shift by 6, 12, 18, 8, or 16.
+It's is important you bind your shifter to Extra Gears 1-6/8 not Base Games 1-6/8.
 
 Now Supports Multiplayer Correctly.
 ]]></en>
@@ -33,6 +34,7 @@ Weitere Gänge fügt Tastenbelegungen für bis zum 18. Gang hinzu. Für direkten
 Für alle mit einer sechs- oder achtfach SchaltungWeiterhin kann ausserdem "Shift" belegt werden, um die Selben sechs oder acht Gänge auch zur Schaltung in die höheren Gänge zu nutzen. Ähnlich wie bei anderen Simulationsspielen.
 
 Es kann um 6, 12, 18, 8, or 16 Gänge geschaltet werden.
+Es ist wichtig, dass Sie Ihren Schalthebel an Extra Gears 1-6/8 und nicht an Base Games 1-6/8 binden.
 
 Unterstützt jetzt den Multiplayer korrekt.
 ]]></de>
@@ -46,6 +48,7 @@ Mod Extra rychlostní stupně přivádá možnost až do 18. Pro přímý přís
 Navíc pro ty, kteří mají šesti nebo osmi rychlostní řadící páku, můžete vytvořit zkratku pro použití stejných stupňů k přístupu do vyšších stupňů. Tak jako jste zvyklí z jiných simulátorů.
 
 Nyní můžete řadit po 6, 12, 18, 8 nebo 16.
+Je důležité, abyste řadicí páku navázali na Extra Gears 1-6/8, nikoli na Base Games 1-6/8.
 
 Nyní také s podporou Multiplayeru.
 ]]></cz>
@@ -59,6 +62,7 @@ Marce Extra aggiunge combinazioni di tasti fino a 18. Per l'accesso diretto al c
 Inoltre, per quelli con un cambio a sei o otto velocità, puoi associare i tasti "shift" per utilizzare gli stessi sei o otto per accedere a marce più alte. Questo è simile ad altri giochi di simulazione.
 
 Puoi cambiare di 6, 12, 18, 8 o 16.
+È importante che leghi il tuo cambio a Extra Gears 1-6/8 e non a Base Games 1-6/8.
 
 Ora supporta correttamente il multiplayer.
 ]]></it>
@@ -72,6 +76,7 @@ Extra versnellingen voegt toetsencombinaties tot de 18e versnelling toe voor dir
 Aanvullend voor de gene met zes of acht versnellingspook, Je kan "shift" toetsen verbinden om de zelfde zes of acht hogere versnellingen te gebruiken. Dit is vergelijkbaar met hoe het in andere Simulator spellen word gedaan.
 
 Je kan per 6, 12, 18, 8, of 16 schakelen.
+Het is belangrijk dat je je shifter bindt aan Extra Gears 1-6/8 en niet aan Base Games 1-6/8.
 
 Ondersteund nu mutiplayer correct
 ]]></nl>
@@ -83,6 +88,15 @@ Ondersteund nu mutiplayer correct
     </extraSourceFiles>
     <l10n filenamePrefix="l10n/l10n" />
     <actions>
+        <action name="EXG_GEAR_1" category="VEHICLE" ignoreComboMask="false" />
+        <action name="EXG_GEAR_2" category="VEHICLE" ignoreComboMask="false" />
+        <action name="EXG_GEAR_3" category="VEHICLE" ignoreComboMask="false" />
+        <action name="EXG_GEAR_4" category="VEHICLE" ignoreComboMask="false" />
+        <action name="EXG_GEAR_5" category="VEHICLE" ignoreComboMask="false" />
+        <action name="EXG_GEAR_6" category="VEHICLE" ignoreComboMask="false" />
+        <action name="EXG_GEAR_7" category="VEHICLE" ignoreComboMask="false" />
+        <action name="EXG_GEAR_8" category="VEHICLE" ignoreComboMask="false" />
+
         <action name="EXG_GEAR_9" category="VEHICLE" ignoreComboMask="false" />
         <action name="EXG_GEAR_10" category="VEHICLE" ignoreComboMask="false" />
         <action name="EXG_GEAR_11" category="VEHICLE" ignoreComboMask="false" />
@@ -109,6 +123,15 @@ Ondersteund nu mutiplayer correct
         <action name="EXG_GEAR_SHIFT_C6" category="VEHICLE" ignoreComboMask="false" />
     </actions>
     <inputBinding>
+        <actionBinding action="EXG_GEAR_1"></actionBinding>
+        <actionBinding action="EXG_GEAR_2"></actionBinding>
+        <actionBinding action="EXG_GEAR_3"></actionBinding>
+        <actionBinding action="EXG_GEAR_4"></actionBinding>
+        <actionBinding action="EXG_GEAR_5"></actionBinding>
+        <actionBinding action="EXG_GEAR_6"></actionBinding>
+        <actionBinding action="EXG_GEAR_7"></actionBinding>
+        <actionBinding action="EXG_GEAR_8"></actionBinding>
+
         <actionBinding action="EXG_GEAR_9"></actionBinding>
         <actionBinding action="EXG_GEAR_10"></actionBinding>
         <actionBinding action="EXG_GEAR_11"></actionBinding>


### PR DESCRIPTION
Patch 1.2 broken extra gears

As the base game changed how the default gearing works.

To work around this provide keybinds for gears 1-8 in the mod and override the behaviour

fixes #12 